### PR TITLE
fix: use index-based pointer arithmetic in slice copy to pass checkptr

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,20 +10,21 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: ['1.24.x', '1.26.x']
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout out code
-        uses: actions/checkout@v3
-      - name: Vet & test
-        run: |
-          # Vet & test
-          go install golang.org/x/lint/golint@latest
-          go vet -v ./...
-          go test -v ./...
-          golint -set_exit_status ./...
+      - name: Vet
+        run: go vet -v ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+      - name: Test
+        run: go test -race -v ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Vet
         run: go vet -v ./...
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,6 @@ gen:
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@protoc --go_out=./proto --proto_path=./proto --go_opt=paths=source_relative ./proto/*.proto
 
-
+test:
+	golangci-lint run --fix ./...
+	go test -race -v ./...

--- a/copier.go
+++ b/copier.go
@@ -452,14 +452,14 @@ func valConv(dstType, srcType reflect.Type) (func(unsafe.Pointer, unsafe.Pointer
 			}
 			len := srcSlice.Len()
 			dstSlice := reflect.MakeSlice(dstType, len, len)
-			srcPtr := srcSlice.UnsafePointer()
-			dstPtr := dstSlice.UnsafePointer()
+			srcBase := srcSlice.UnsafePointer()
+			dstBase := dstSlice.UnsafePointer()
 			for i := 0; i < len; i++ {
+				dstPtr := unsafe.Add(dstBase, uintptr(i)*dstElSize)
+				srcPtr := unsafe.Add(srcBase, uintptr(i)*srcElSize)
 				if err := elConv(dstPtr, srcPtr); err != nil {
 					return err
 				}
-				dstPtr = unsafe.Add(dstPtr, dstElSize)
-				srcPtr = unsafe.Add(srcPtr, srcElSize)
 			}
 			reflect.NewAt(dstType, dst).Elem().Set(dstSlice)
 			return nil

--- a/copier_test.go
+++ b/copier_test.go
@@ -1105,6 +1105,49 @@ func TestValConv(t *testing.T) {
 		req.Equal([]alias{12, 34, 56}, dst)
 	})
 
+	t.Run("[]int -> []int (nil)", func(t *testing.T) {
+		req := require.New(t)
+
+		var (
+			dst []int
+			src []int
+		)
+		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
+		req.NoError(err)
+		err = f(unsafe.Pointer(&dst), unsafe.Pointer(&src))
+		req.NoError(err)
+		req.Nil(dst)
+	})
+
+	t.Run("[]int -> []int (empty)", func(t *testing.T) {
+		req := require.New(t)
+
+		var (
+			dst []int
+			src = []int{}
+		)
+		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
+		req.NoError(err)
+		err = f(unsafe.Pointer(&dst), unsafe.Pointer(&src))
+		req.NoError(err)
+		req.NotNil(dst)
+		req.Empty(dst)
+	})
+
+	t.Run("[]int32 -> []int64", func(t *testing.T) {
+		req := require.New(t)
+
+		var (
+			dst []int64
+			src = []int32{12, 34, 56}
+		)
+		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
+		req.NoError(err)
+		err = f(unsafe.Pointer(&dst), unsafe.Pointer(&src))
+		req.NoError(err)
+		req.Equal([]int64{12, 34, 56}, dst)
+	})
+
 	t.Run("*int -> Maybe[int]", func(t *testing.T) {
 		req := require.New(t)
 

--- a/copier_test.go
+++ b/copier_test.go
@@ -1038,7 +1038,7 @@ func TestValConv(t *testing.T) {
 
 		var (
 			dst int
-			src int = 1234
+			src = 1234
 		)
 		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
 		req.NoError(err)
@@ -1052,7 +1052,7 @@ func TestValConv(t *testing.T) {
 
 		var (
 			dst *int
-			src *int = pointer.To(1234)
+			src = pointer.To(1234)
 		)
 		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
 		req.NoError(err)
@@ -1067,7 +1067,7 @@ func TestValConv(t *testing.T) {
 		type alias int
 		var (
 			dst alias
-			src int = 1234
+			src = 1234
 		)
 		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
 		req.NoError(err)
@@ -1167,7 +1167,7 @@ func TestValConv(t *testing.T) {
 		u := ulid.Make()
 		var (
 			dst maybe.Maybe[ulid.ULID]
-			src *string = pointer.To(u.String())
+			src = pointer.To(u.String())
 		)
 		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
 		req.NoError(err)
@@ -1181,7 +1181,7 @@ func TestValConv(t *testing.T) {
 
 		var (
 			dst maybe.Maybe[decimal.Decimal]
-			src *string = pointer.To("1234")
+			src = pointer.To("1234")
 		)
 		f, err := valConv(reflect.TypeOf(dst), reflect.TypeOf(src))
 		req.NoError(err)


### PR DESCRIPTION
Go 1.26.2 tightened checkptr validation (enabled by -race), which caught the slice copy loop in copier.go advancing pointers past the allocation boundary after the last element. The fix computes element pointers from a base address using the loop index. CI updated to Go 1.24-1.26 with golangci-lint and -race, make test added for local runs. 